### PR TITLE
Use Bach.java 1.0.0

### DIFF
--- a/bach-build-run.jsh
+++ b/bach-build-run.jsh
@@ -4,7 +4,7 @@
  * Download "Bach.java" and "Bach.jsh" from github to local "target" directory.
  */
 Path target = Files.createDirectories(Paths.get("target"))
-URL context = new URL("https://raw.githubusercontent.com/sormuras/bach/master/src/bach/")
+URL context = new URL("https://raw.githubusercontent.com/sormuras/bach/1.0.0/src/bach/")
 for (Path script : Set.of(target.resolve("Bach.java"), target.resolve("Bach.jsh"))) {
     if (Files.exists(script)) continue; // comment to force download files
     try (InputStream stream = new URL(context, script.getFileName().toString()).openStream()) {


### PR DESCRIPTION
Prior to this commit, the build script depended on "current master" version of `Bach.java` -- which is now using Java 10 syntax. This commit ensures that a Java 9 compatible version of `Bach.java` is
loaded from Github.