### PR TITLE
[WIP] Introduce test module

### DIFF
--- a/pom-test-modules.jsh
+++ b/pom-test-modules.jsh
@@ -1,0 +1,36 @@
+//usr/bin/env jshell --show-version --execution local "$0" "$@"; exit $?
+
+/*
+ * Download "Bach.java" and "Bach.jsh" from github to local "target" directory.
+ */
+Path target = Files.createDirectories(Paths.get("target"))
+URL context = new URL("https://raw.githubusercontent.com/sormuras/bach/1.0.0/src/bach/")
+for (Path script : Set.of(target.resolve("Bach.java"), target.resolve("Bach.jsh"))) {
+    if (Files.exists(script)) continue; // comment to force download files
+    try (InputStream stream = new URL(context, script.getFileName().toString()).openStream()) {
+        Files.copy(stream, script, StandardCopyOption.REPLACE_EXISTING);
+    }
+}
+
+/*
+ * Switch Bach to verbose mode. That'll print the commands before execution.
+ */
+System.setProperty("bach.verbose", "true")
+
+/*
+ * Source "Bach.java" and "Bach.jsh" into this jshell session.
+ */
+/open target/Bach.java
+/open target/Bach.jsh
+
+/*
+ * Launch JUnit Platform Console.
+ */
+Bach.JdkTool.Java command = new Bach.JdkTool.Java()
+command.modulePath = List.of(Paths.get("target/test-classes"), Paths.get("target/lib"))
+command.addModules = List.of("ALL-MODULE-PATH,ALL-DEFAULT")
+command.module = "org.junit.platform.console"
+command.args = List.of("--scan-modules")
+command.run()
+
+/exit

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,29 @@
 		<maven.compiler.target>9</maven.compiler.target>
 	</properties>
 
+	<dependencies>
+		<!-- test-compile -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>5.2.0</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- test-runtime -->
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-console</artifactId>
+			<version>1.2.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>5.2.0</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -22,7 +45,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.7.0</version>
+				<version>3.7.1-SNAPSHOT</version>
 				<configuration>
 					<fork>true</fork>
 				</configuration>
@@ -31,6 +54,39 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>3.0.2</version>
+			</plugin>
+			<plugin>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>test</phase>
+						<goals>
+							<goal>copy-dependencies</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${project.build.directory}/lib</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>1.6.0</version>
+				<executions>
+					<execution>
+						<phase>test</phase>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<executable>jshell</executable>
+					<arguments>
+						<argument>pom-test-modules.jsh</argument>
+					</arguments>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/test/java/module-info.java
+++ b/src/test/java/module-info.java
@@ -1,0 +1,8 @@
+open module org.codefx.demo.jpms_hello_world {
+	// main: copied from "main" module
+	requires java.base;
+	exports org.codefx.demo.jpms;
+
+	// test: needed for modular testing
+	requires org.junit.jupiter.api;
+}

--- a/src/test/java/org/codefx/demo/jpms/HelloModularWorldTests.java
+++ b/src/test/java/org/codefx/demo/jpms/HelloModularWorldTests.java
@@ -1,0 +1,14 @@
+package org.codefx.demo.jpms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class HelloModularWorldTests {
+
+	@Test
+	void test() {
+		String actual = HelloModularWorld.class.getModule().getName();
+		assertEquals("org.codefx.demo.jpms_hello_world", actual);
+	}
+}


### PR DESCRIPTION
**DO NOT MERGE!** It's in a work-in-progress state! Need this PR so easily compare the changes to the simple and "test-less" project.

`maven-compiler-plugin` **3.7.1** will support compiling `module-info.java` files located in `src/test/java`.

For details see https://issues.apache.org/jira/browse/MCOMPILER-341

### TODO

- [ ] Convert `pom-test-modules.jsh` into an `exec-maven-plugin` block inside `pom.xml`
- [ ] Move entire "modular testing logic" into Surefire...