### PR TITLE
Introduce modular test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,15 @@
 		<maven.compiler.target>9</maven.compiler.target>
 	</properties>
 
+	<dependencies>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>5.2.0</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -22,7 +31,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.7.0</version>
+				<version>3.8.0</version>
 				<configuration>
 					<fork>true</fork>
 				</configuration>
@@ -31,6 +40,18 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>3.0.2</version>
+			</plugin>
+			<plugin>
+				<groupId>de.sormuras</groupId>
+				<artifactId>junit-platform-maven-plugin</artifactId>
+				<version>0.0.7</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>launch-junit-platform</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/test/java/module-info.java
+++ b/src/test/java/module-info.java
@@ -1,0 +1,8 @@
+open module org.codefx.demo.jpms_hello_world {
+	// main: copied from "main" module
+	requires java.base;
+	exports org.codefx.demo.jpms;
+
+	// test: needed for modular testing
+	requires org.junit.jupiter.api;
+}

--- a/src/test/java/org/codefx/demo/jpms/HelloModularWorldTests.java
+++ b/src/test/java/org/codefx/demo/jpms/HelloModularWorldTests.java
@@ -1,0 +1,14 @@
+package org.codefx.demo.jpms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class HelloModularWorldTests {
+
+	@Test
+	void test() {
+		String actual = HelloModularWorld.class.getModule().getName();
+		assertEquals("org.codefx.demo.jpms_hello_world", actual);
+	}
+}


### PR DESCRIPTION
- `maven-compiler-plugin` 3.8.0 supports compiling `module-info.java` files located in test source locations.
- `junit-platform-maven-plugin` supports finding and executing such compiled test modules.

Looks like this on the console:

```
[INFO] --- junit-platform-maven-plugin:0.0.7:launch-junit-platform (default) @ jpms-hello-world
[INFO] Launching JUnit Platform...
[INFO] .
[INFO] '-- JUnit Jupiter [OK]
[INFO]   '-- HelloModularWorldTests [OK]
[INFO]     '-- test() [OK]
[INFO] 
[INFO] Test run finished after 102 ms
[INFO] [         2 containers found      ]
[INFO] [         0 containers skipped    ]
[INFO] [         2 containers started    ]
[INFO] [         0 containers aborted    ]
[INFO] [         2 containers successful ]
[INFO] [         0 containers failed     ]
[INFO] [         1 tests found           ]
[INFO] [         0 tests skipped         ]
[INFO] [         1 tests started         ]
[INFO] [         0 tests aborted         ]
[INFO] [         1 tests successful      ]
[INFO] [         0 tests failed          ]
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 3.494 s
```